### PR TITLE
Add usecase unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/MarioFronza/media-tui
+
+go 1.23.4

--- a/internal/usecase/library_test.go
+++ b/internal/usecase/library_test.go
@@ -1,0 +1,84 @@
+package usecase
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MarioFronza/media-tui/internal/domain"
+)
+
+func TestLibrary_List_DelegatesToRepo(t *testing.T) {
+	want := []domain.LibraryItem{
+		{ID: 1, Title: "The Matrix", MediaType: domain.MediaTypeMovie},
+	}
+	repo := &mockRepo{
+		getLibraryFn: func() ([]domain.LibraryItem, error) {
+			return want, nil
+		},
+	}
+
+	uc := NewLibraryUseCase(repo)
+	got, err := uc.List()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d items, got %d", len(want), len(got))
+	}
+	if got[0].Title != want[0].Title {
+		t.Errorf("expected title %q, got %q", want[0].Title, got[0].Title)
+	}
+}
+
+func TestLibrary_List_PropagatesError(t *testing.T) {
+	repo := &mockRepo{
+		getLibraryFn: func() ([]domain.LibraryItem, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+
+	uc := NewLibraryUseCase(repo)
+	_, err := uc.List()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestLibrary_Add_DelegatesToRepo(t *testing.T) {
+	item := domain.MediaItem{ID: 42, Title: "Dune", Type: domain.MediaTypeMovie}
+	var received domain.MediaItem
+
+	repo := &mockRepo{
+		addFn: func(i domain.MediaItem) error {
+			received = i
+			return nil
+		},
+	}
+
+	uc := NewLibraryUseCase(repo)
+	err := uc.Add(item)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if received.ID != item.ID || received.Title != item.Title {
+		t.Errorf("repo received wrong item: %+v", received)
+	}
+}
+
+func TestLibrary_Add_PropagatesError(t *testing.T) {
+	repo := &mockRepo{
+		addFn: func(item domain.MediaItem) error {
+			return errors.New("already exists")
+		},
+	}
+
+	uc := NewLibraryUseCase(repo)
+	err := uc.Add(domain.MediaItem{ID: 1, Title: "Dune"})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/usecase/mock_test.go
+++ b/internal/usecase/mock_test.go
@@ -1,0 +1,43 @@
+package usecase
+
+import "github.com/MarioFronza/media-tui/internal/domain"
+
+type mockRepo struct {
+	searchFn     func(term string) ([]domain.MediaItem, error)
+	addFn        func(item domain.MediaItem) error
+	getLibraryFn func() ([]domain.LibraryItem, error)
+	getQueueFn   func() ([]domain.QueueItem, error)
+	mediaType    domain.MediaType
+}
+
+func (m *mockRepo) Search(term string) ([]domain.MediaItem, error) {
+	if m.searchFn != nil {
+		return m.searchFn(term)
+	}
+	return nil, nil
+}
+
+func (m *mockRepo) Add(item domain.MediaItem) error {
+	if m.addFn != nil {
+		return m.addFn(item)
+	}
+	return nil
+}
+
+func (m *mockRepo) GetLibrary() ([]domain.LibraryItem, error) {
+	if m.getLibraryFn != nil {
+		return m.getLibraryFn()
+	}
+	return nil, nil
+}
+
+func (m *mockRepo) GetQueue() ([]domain.QueueItem, error) {
+	if m.getQueueFn != nil {
+		return m.getQueueFn()
+	}
+	return nil, nil
+}
+
+func (m *mockRepo) MediaType() domain.MediaType {
+	return m.mediaType
+}

--- a/internal/usecase/queue_test.go
+++ b/internal/usecase/queue_test.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MarioFronza/media-tui/internal/domain"
+)
+
+func TestQueue_MultipleRepos_AggregatesItems(t *testing.T) {
+	repo1 := &mockRepo{
+		getQueueFn: func() ([]domain.QueueItem, error) {
+			return []domain.QueueItem{{ID: 1, Title: "Movie Download", MediaType: domain.MediaTypeMovie}}, nil
+		},
+	}
+	repo2 := &mockRepo{
+		getQueueFn: func() ([]domain.QueueItem, error) {
+			return []domain.QueueItem{{ID: 2, Title: "Series Download", MediaType: domain.MediaTypeSeries}}, nil
+		},
+	}
+
+	uc := NewQueueUseCase(repo1, repo2)
+	got, err := uc.Execute()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 queue items, got %d", len(got))
+	}
+}
+
+func TestQueue_OneRepoErrors_ContinuesOthers(t *testing.T) {
+	errRepo := &mockRepo{
+		getQueueFn: func() ([]domain.QueueItem, error) {
+			return nil, errors.New("service unavailable")
+		},
+	}
+	okRepo := &mockRepo{
+		getQueueFn: func() ([]domain.QueueItem, error) {
+			return []domain.QueueItem{{ID: 1, Title: "Active Download"}}, nil
+		},
+	}
+
+	uc := NewQueueUseCase(errRepo, okRepo)
+	got, err := uc.Execute()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 item from healthy repo, got %d", len(got))
+	}
+}
+
+func TestQueue_NoRepos_ReturnsEmptyNilError(t *testing.T) {
+	uc := NewQueueUseCase()
+	got, err := uc.Execute()
+
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result, got %v", got)
+	}
+}

--- a/internal/usecase/search_test.go
+++ b/internal/usecase/search_test.go
@@ -1,0 +1,103 @@
+package usecase
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MarioFronza/media-tui/internal/domain"
+)
+
+func TestSearch_SingleRepo_ReturnsResults(t *testing.T) {
+	want := []domain.MediaItem{
+		{ID: 1, Title: "Inception", Type: domain.MediaTypeMovie},
+	}
+	repo := &mockRepo{
+		searchFn: func(term string) ([]domain.MediaItem, error) {
+			return want, nil
+		},
+	}
+
+	uc := NewSearchUseCase(repo)
+	got := uc.Execute("inception")
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d results, got %d", len(want), len(got))
+	}
+	if got[0].Title != want[0].Title {
+		t.Errorf("expected title %q, got %q", want[0].Title, got[0].Title)
+	}
+}
+
+func TestSearch_MultipleRepos_AggregatesResults(t *testing.T) {
+	repo1 := &mockRepo{
+		searchFn: func(term string) ([]domain.MediaItem, error) {
+			return []domain.MediaItem{{ID: 1, Title: "Movie A", Type: domain.MediaTypeMovie}}, nil
+		},
+	}
+	repo2 := &mockRepo{
+		searchFn: func(term string) ([]domain.MediaItem, error) {
+			return []domain.MediaItem{{ID: 2, Title: "Series B", Type: domain.MediaTypeSeries}}, nil
+		},
+	}
+
+	uc := NewSearchUseCase(repo1, repo2)
+	got := uc.Execute("test")
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 aggregated results, got %d", len(got))
+	}
+}
+
+func TestSearch_OneRepoErrors_SkipsIt(t *testing.T) {
+	errRepo := &mockRepo{
+		searchFn: func(term string) ([]domain.MediaItem, error) {
+			return nil, errors.New("timeout")
+		},
+	}
+	okRepo := &mockRepo{
+		searchFn: func(term string) ([]domain.MediaItem, error) {
+			return []domain.MediaItem{{ID: 1, Title: "Good Result"}}, nil
+		},
+	}
+
+	uc := NewSearchUseCase(errRepo, okRepo)
+	got := uc.Execute("test")
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 result from healthy repo, got %d", len(got))
+	}
+	if got[0].Title != "Good Result" {
+		t.Errorf("unexpected title: %q", got[0].Title)
+	}
+}
+
+func TestSearch_NoRepos_ReturnsEmpty(t *testing.T) {
+	uc := NewSearchUseCase()
+	got := uc.Execute("anything")
+
+	if got != nil && len(got) != 0 {
+		t.Fatalf("expected empty result, got %v", got)
+	}
+}
+
+func TestSearch_Concurrent_AllReposQueried(t *testing.T) {
+	var callCount int64
+
+	makeRepo := func() *mockRepo {
+		return &mockRepo{
+			searchFn: func(term string) ([]domain.MediaItem, error) {
+				atomic.AddInt64(&callCount, 1)
+				return nil, nil
+			},
+		}
+	}
+
+	repos := []domain.MediaRepository{makeRepo(), makeRepo(), makeRepo()}
+	uc := NewSearchUseCase(repos...)
+	uc.Execute("test")
+
+	if callCount != 3 {
+		t.Errorf("expected 3 repos queried, got %d", callCount)
+	}
+}


### PR DESCRIPTION
Unit tests for search, library, and queue usecases using a local mock — no external dependencies.