### PR TITLE
feat: implement queue screen

### DIFF
--- a/cmd/media-tui/main.go
+++ b/cmd/media-tui/main.go
@@ -12,7 +12,8 @@ import (
 
 func main() {
 	searchUC := usecase.NewSearchUseCase()
-	p := tea.NewProgram(ui.NewApp(searchUC), tea.WithAltScreen())
+	queueUC := usecase.NewQueueUseCase()
+	p := tea.NewProgram(ui.NewApp(searchUC, queueUC), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -37,12 +37,12 @@ type App struct {
 	height  int
 }
 
-func NewApp(searchUC *usecase.SearchUseCase, libraryUCs ...*usecase.LibraryUseCase) App {
+func NewApp(searchUC *usecase.SearchUseCase, queueUC *usecase.QueueUseCase, libraryUCs ...*usecase.LibraryUseCase) App {
 	return App{
 		current: screenSearch,
 		search:  NewSearchModel(searchUC),
 		library: NewLibraryModel(libraryUCs...),
-		queue:   NewQueueModel(),
+		queue:   NewQueueModel(queueUC),
 		detail:  NewDetailModel(),
 	}
 }

--- a/internal/ui/queue.go
+++ b/internal/ui/queue.go
@@ -1,13 +1,123 @@
 package ui
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
-type QueueModel struct{}
+	"github.com/MarioFronza/media-tui/internal/domain"
+	"github.com/MarioFronza/media-tui/internal/usecase"
+)
 
-func NewQueueModel() QueueModel { return QueueModel{} }
+type queueResultMsg struct {
+	items []domain.QueueItem
+}
 
-func (m QueueModel) Init() tea.Cmd { return nil }
+type QueueModel struct {
+	usecase *usecase.QueueUseCase
+	spinner spinner.Model
+	table   table.Model
+	items   []domain.QueueItem
+	loading bool
+}
 
-func (m QueueModel) Update(msg tea.Msg) (QueueModel, tea.Cmd) { return m, nil }
+func NewQueueModel(uc *usecase.QueueUseCase) QueueModel {
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 
-func (m QueueModel) View() string { return "Queue screen — coming soon" }
+	cols := []table.Column{
+		{Title: "Title", Width: 40},
+		{Title: "Service", Width: 10},
+		{Title: "Status", Width: 12},
+		{Title: "Time Left", Width: 12},
+	}
+	t := table.New(
+		table.WithColumns(cols),
+		table.WithFocused(true),
+		table.WithHeight(15),
+	)
+	t.SetStyles(tableStyles())
+
+	return QueueModel{
+		usecase: uc,
+		spinner: sp,
+		table:   t,
+	}
+}
+
+func (m QueueModel) Init() tea.Cmd {
+	_, cmd := m.fetchQueue()
+	return cmd
+}
+
+func (m QueueModel) Update(msg tea.Msg) (QueueModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	case queueResultMsg:
+		return m.handleResult(msg)
+	case spinner.TickMsg:
+		return m.updateSpinner(msg)
+	}
+	return m.updateTable(msg)
+}
+
+func (m QueueModel) handleKey(msg tea.KeyMsg) (QueueModel, tea.Cmd) {
+	switch msg.String() {
+	case "r":
+		return m.fetchQueue()
+	}
+	return m.updateTable(msg)
+}
+
+func (m QueueModel) handleResult(msg queueResultMsg) (QueueModel, tea.Cmd) {
+	m.loading = false
+	m.items = msg.items
+	m.table.SetRows(toQueueRows(msg.items))
+	return m, nil
+}
+
+func (m QueueModel) updateSpinner(msg spinner.TickMsg) (QueueModel, tea.Cmd) {
+	var cmd tea.Cmd
+	m.spinner, cmd = m.spinner.Update(msg)
+	return m, cmd
+}
+
+func (m QueueModel) updateTable(msg tea.Msg) (QueueModel, tea.Cmd) {
+	var cmd tea.Cmd
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+func (m QueueModel) fetchQueue() (QueueModel, tea.Cmd) {
+	m.loading = true
+	return m, tea.Batch(m.spinner.Tick, func() tea.Msg {
+		items, _ := m.usecase.Execute()
+		return queueResultMsg{items: items}
+	})
+}
+
+func (m QueueModel) View() string {
+	header := lipgloss.NewStyle().Bold(true).Render("Queue") + "\n\n"
+
+	if m.loading {
+		return header + m.spinner.View() + " Loading..."
+	}
+
+	if len(m.items) == 0 {
+		return header + "No items in queue."
+	}
+
+	hint := lipgloss.NewStyle().Faint(true).Render("r refresh · ↑/↓ navigate")
+	return header + m.table.View() + "\n" + hint
+}
+
+func toQueueRows(items []domain.QueueItem) []table.Row {
+	rows := make([]table.Row, 0, len(items))
+	for _, item := range items {
+		rows = append(rows, table.Row{item.Title, string(item.MediaType), item.Status, item.TimeLeft})
+	}
+	return rows
+}


### PR DESCRIPTION
## Summary

- Implements `internal/ui/queue.go` as a full Bubbletea sub-model
- Aggregates download queue from all enabled services via `QueueUseCase`
- Table with columns: Title, Service (MediaType), Status, Time Left
- Spinner while loading; `r` key to refresh; empty state message
- Updates `NewApp` and `NewQueueModel` signatures to accept `*usecase.QueueUseCase`

## Test plan

- [ ] Navigate to Queue tab (`q` key) — spinner appears then table loads
- [ ] Press `r` to refresh queue
- [ ] Empty queue shows "No items in queue."

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)