### PR TITLE
feat: implement detail screen and wire main.go

### DIFF
--- a/cmd/media-tui/main.go
+++ b/cmd/media-tui/main.go
@@ -6,14 +6,51 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/MarioFronza/media-tui/internal/adapter/api"
+	"github.com/MarioFronza/media-tui/internal/adapter/config"
+	"github.com/MarioFronza/media-tui/internal/domain"
 	"github.com/MarioFronza/media-tui/internal/ui"
 	"github.com/MarioFronza/media-tui/internal/usecase"
 )
 
 func main() {
-	searchUC := usecase.NewSearchUseCase()
-	queueUC := usecase.NewQueueUseCase()
-	p := tea.NewProgram(ui.NewApp(searchUC, queueUC), tea.WithAltScreen())
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	var repos []domain.MediaRepository
+	var libraryUCs []*usecase.LibraryUseCase
+
+	if cfg.Radarr.Enabled {
+		adapter := api.NewRadarrAdapter(cfg.Radarr.URL, cfg.Radarr.APIKey)
+		repos = append(repos, adapter)
+		libraryUCs = append(libraryUCs, usecase.NewLibraryUseCase(adapter))
+	}
+
+	if cfg.Sonarr.Enabled {
+		adapter := api.NewSonarrAdapter(cfg.Sonarr.URL, cfg.Sonarr.APIKey)
+		repos = append(repos, adapter)
+		libraryUCs = append(libraryUCs, usecase.NewLibraryUseCase(adapter))
+	}
+
+	if cfg.Lidarr.Enabled {
+		adapter := api.NewLidarrAdapter(cfg.Lidarr.URL, cfg.Lidarr.APIKey)
+		repos = append(repos, adapter)
+		libraryUCs = append(libraryUCs, usecase.NewLibraryUseCase(adapter))
+	}
+
+	if cfg.Readarr.Enabled {
+		adapter := api.NewReadarrAdapter(cfg.Readarr.URL, cfg.Readarr.APIKey)
+		repos = append(repos, adapter)
+		libraryUCs = append(libraryUCs, usecase.NewLibraryUseCase(adapter))
+	}
+
+	searchUC := usecase.NewSearchUseCase(repos...)
+	queueUC := usecase.NewQueueUseCase(repos...)
+
+	p := tea.NewProgram(ui.NewApp(searchUC, queueUC, libraryUCs...), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -28,22 +28,24 @@ type SwitchToDetailMsg struct {
 }
 
 type App struct {
-	current screen
-	search  SearchModel
-	library LibraryModel
-	queue   QueueModel
-	detail  DetailModel
-	width   int
-	height  int
+	current    screen
+	search     SearchModel
+	library    LibraryModel
+	queue      QueueModel
+	detail     DetailModel
+	libraryUCs []*usecase.LibraryUseCase
+	width      int
+	height     int
 }
 
 func NewApp(searchUC *usecase.SearchUseCase, queueUC *usecase.QueueUseCase, libraryUCs ...*usecase.LibraryUseCase) App {
 	return App{
-		current: screenSearch,
-		search:  NewSearchModel(searchUC),
-		library: NewLibraryModel(libraryUCs...),
-		queue:   NewQueueModel(queueUC),
-		detail:  NewDetailModel(),
+		current:    screenSearch,
+		search:     NewSearchModel(searchUC),
+		library:    NewLibraryModel(libraryUCs...),
+		queue:      NewQueueModel(queueUC),
+		detail:     NewDetailModel(),
+		libraryUCs: libraryUCs,
 	}
 }
 
@@ -90,7 +92,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case SwitchToDetailMsg:
-		a.detail = NewDetailModelWithItem(msg.Item)
+		a.detail = NewDetailModelWithItem(msg.Item, a.ucForItem(msg.Item))
 		a.current = screenDetail
 		return a, a.detail.Init()
 	}
@@ -143,4 +145,20 @@ func (a App) tab(label string, s screen) string {
 		return activeTabStyle.Render(label)
 	}
 	return tabStyle.Render(label)
+}
+
+// ucForItem returns the LibraryUseCase that matches the item's media type.
+// The libraryUCs slice is ordered: [0] Radarr (movie), [1] Sonarr (series),
+// [2] Lidarr (artist), [3] Readarr (book). Returns nil if none available.
+func (a App) ucForItem(item domain.MediaItem) *usecase.LibraryUseCase {
+	idx := map[domain.MediaType]int{
+		domain.MediaTypeMovie:  0,
+		domain.MediaTypeSeries: 1,
+		domain.MediaTypeArtist: 2,
+		domain.MediaTypeBook:   3,
+	}
+	if i, ok := idx[item.Type]; ok && i < len(a.libraryUCs) {
+		return a.libraryUCs[i]
+	}
+	return nil
 }

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -1,21 +1,104 @@
 package ui
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/MarioFronza/media-tui/internal/domain"
+	"github.com/MarioFronza/media-tui/internal/usecase"
+)
+
+type addResultMsg struct{ err error }
+
+var (
+	labelStyle   = lipgloss.NewStyle().Bold(true)
+	dividerStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	hintStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	successStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
+	errorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	addingStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 )
 
 type DetailModel struct {
-	item domain.MediaItem
+	item    domain.MediaItem
+	usecase *usecase.LibraryUseCase
+	status  string // "", "adding", "added", "error: ..."
 }
 
 func NewDetailModel() DetailModel { return DetailModel{} }
 
-func NewDetailModelWithItem(item domain.MediaItem) DetailModel { return DetailModel{item: item} }
+func NewDetailModelWithItem(item domain.MediaItem, uc *usecase.LibraryUseCase) DetailModel {
+	return DetailModel{item: item, usecase: uc}
+}
 
 func (m DetailModel) Init() tea.Cmd { return nil }
 
-func (m DetailModel) Update(msg tea.Msg) (DetailModel, tea.Cmd) { return m, nil }
+func (m DetailModel) Update(msg tea.Msg) (DetailModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return m, func() tea.Msg {
+				return SwitchScreenMsg{Target: screenSearch}
+			}
+		case "a", "enter":
+			if m.usecase == nil || m.status == "adding" || m.status == "added" || m.item.Added {
+				return m, nil
+			}
+			m.status = "adding"
+			item := m.item
+			uc := m.usecase
+			return m, func() tea.Msg {
+				err := uc.Add(item)
+				return addResultMsg{err: err}
+			}
+		}
 
-func (m DetailModel) View() string { return "Detail screen — coming soon" }
+	case addResultMsg:
+		if msg.err != nil {
+			m.status = fmt.Sprintf("error: %s", msg.err.Error())
+		} else {
+			m.status = "added"
+		}
+	}
+
+	return m, nil
+}
+
+func (m DetailModel) View() string {
+	divider := dividerStyle.Render("──────────────────────────")
+
+	title := fmt.Sprintf("%s %s", labelStyle.Render("Title:"), m.item.Title)
+	year := fmt.Sprintf("%s %d", labelStyle.Render("Year:"), m.item.Year)
+	mediaType := fmt.Sprintf("%s %s", labelStyle.Render("Type:"), string(m.item.Type))
+	overview := fmt.Sprintf("%s %s", labelStyle.Render("Overview:"), m.item.Overview)
+
+	var statusLine string
+	switch {
+	case m.item.Added || m.status == "added":
+		if m.status == "added" {
+			statusLine = successStyle.Render("Added successfully!")
+		} else {
+			statusLine = successStyle.Render("Already in library")
+		}
+	case m.status == "adding":
+		statusLine = addingStyle.Render("Adding...")
+	case len(m.status) > 6 && m.status[:6] == "error:":
+		statusLine = errorStyle.Render(m.status)
+	default:
+		statusLine = hintStyle.Render("a/Enter add to library · Esc back")
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		labelStyle.Render("Detail"),
+		divider,
+		title,
+		year,
+		mediaType,
+		overview,
+		"",
+		statusLine,
+	)
+}


### PR DESCRIPTION
## Summary

- Implements `internal/ui/detail.go` — shows item metadata, `a`/Enter to add via `LibraryUseCase`, Esc to go back
- Updates `internal/ui/app.go` — stores library usecases, maps `MediaType` to the correct `LibraryUseCase` when opening detail
- Rewrites `cmd/media-tui/main.go` — loads config, instantiates enabled *arr adapters, wires all usecases into the UI

## Test plan

- [ ] Search for an item, press Enter — detail screen shows title, year, type, overview
- [ ] Press `a` or Enter on detail screen — item is added, success message shown
- [ ] Press Esc — returns to search screen
- [ ] Disabled services in `config.yaml` are skipped at startup

Closes #16
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)